### PR TITLE
Allow both unquoted and quoted keys.

### DIFF
--- a/transforms/sort-object-props.js
+++ b/transforms/sort-object-props.js
@@ -17,7 +17,8 @@ function sortPropsByName (a, b) {
 }
 
 function getPropNameForSort (prop) {
-  return prop.key ? prop.key.name : ''
+  // Allow both unquoted and quoted keys.
+  return prop.key && ( prop.key.name || prop.key.value ) || '';
 }
 
 function applySort (a, b) {


### PR DESCRIPTION
e.g.

var obj = {
  b: b,
  'a': a,
  'remains-quoted': 'cause dashes are illegal in keys',
  quoted: 'yaay',
};

turns into: 

const obj = {
  a: a,
  b: b,
  quoted: 'yaay',
  'remains-quoted': 'cause dashes are illegal in keys',
};